### PR TITLE
Fixed the use of undenoised latent from the DPM++ scheduler

### DIFF
--- a/Sources/GuernikaKit/StableDiffusion/StableDiffusionMainPipeline.swift
+++ b/Sources/GuernikaKit/StableDiffusion/StableDiffusionMainPipeline.swift
@@ -271,7 +271,7 @@ public class StableDiffusionMainPipeline: StableDiffusionPipeline {
         }
 
         // Decode the latent sample to image
-        let image = try decodeToImage(latent)
+        let image = try decodeToImage(scheduler.modelOutputs.last ?? latent)
         
         if reduceMemory {
             decoder.unloadResources()

--- a/Sources/GuernikaKit/StableDiffusion/StableDiffusionPix2PixPipeline.swift
+++ b/Sources/GuernikaKit/StableDiffusion/StableDiffusionPix2PixPipeline.swift
@@ -227,7 +227,7 @@ public class StableDiffusionPix2PixPipeline: StableDiffusionPipeline {
         }
 
         // Decode the latent sample to image
-        let image = try decodeToImage(latent)
+        let image = try decodeToImage(scheduler.modelOutputs.last ?? latent)
         
         if reduceMemory {
             decoder.unloadResources()

--- a/Sources/GuernikaKit/StableDiffusion/StableDiffusionXLPipeline.swift
+++ b/Sources/GuernikaKit/StableDiffusion/StableDiffusionXLPipeline.swift
@@ -317,7 +317,7 @@ public class StableDiffusionXLPipeline: StableDiffusionPipeline {
         }
 
         // Decode the latent sample to image
-        let image = try decodeToImage(latent)
+        let image = try decodeToImage(scheduler.modelOutputs.last ?? latent)
         
         if reduceMemory {
             decoder.unloadResources()

--- a/Sources/GuernikaKit/StableDiffusion/StableDiffusionXLRefinerPipeline.swift
+++ b/Sources/GuernikaKit/StableDiffusion/StableDiffusionXLRefinerPipeline.swift
@@ -277,7 +277,7 @@ public class StableDiffusionXLRefinerPipeline: StableDiffusionPipeline {
         }
 
         // Decode the latent sample to image
-        let image = try decodeToImage(latent)
+        let image = try decodeToImage(scheduler.modelOutputs.last ?? latent)
         
         if reduceMemory {
             decoder.unloadResources()


### PR DESCRIPTION
- The latent returned by the step function in DPM++ scheduler is not denoised. It seems to be the prediction of the next time step.
- I don't know much about it. I don't know if this fix is right, but it does solve the picture quality problem. 
- The following is the picture quality comparison of DPM++ 2M Karras before and after the fixed.

![316493631-11d1cbbb-c5af-48ad-9507-903f0233a170](https://github.com/GuernikaCore/GuernikaKit/assets/90698189/06d4241c-f36c-410c-a1d3-8d453168dd2d)
![316493584-314ba683-59f6-4bc1-9cde-2f5108f5adc9](https://github.com/GuernikaCore/GuernikaKit/assets/90698189/20e1e2fc-6c2a-4c0c-8b24-545a6d95e25e)
