### PR TITLE
Add negative size support

### DIFF
--- a/Sources/GuernikaKit/StableDiffusion/StableDiffusionXLPipeline.swift
+++ b/Sources/GuernikaKit/StableDiffusion/StableDiffusionXLPipeline.swift
@@ -178,7 +178,7 @@ public class StableDiffusionXLPipeline: StableDiffusionPipeline {
         )
         
         let targetSize = CGSize(width: input.size?.width ?? sampleSize.width, height: input.size?.height ?? sampleSize.height)
-        let negativeScale = 0.5
+        let negativeSize = 512
         // Prepare added time ids & embeddings
         var timeIds = MLShapedArray<Float32>(scalars: [
             // original_size
@@ -192,7 +192,7 @@ public class StableDiffusionXLPipeline: StableDiffusionPipeline {
         if doClassifierFreeGuidance {
             let negativeTimeIds = MLShapedArray<Float32>(scalars: [
                 // original_size (negative)
-                Float32(targetSize.height * negativeScale), Float32(targetSize.width * negativeScale),
+                Float32(negativeSize), Float32(negativeSize),
                 // crops_coords_top_left
                 0, 0,
                 // target_size

--- a/Sources/GuernikaKit/StableDiffusion/StableDiffusionXLPipeline.swift
+++ b/Sources/GuernikaKit/StableDiffusion/StableDiffusionXLPipeline.swift
@@ -177,17 +177,29 @@ public class StableDiffusionXLPipeline: StableDiffusionPipeline {
             prompt: input.prompt, negativePrompt: input.negativePrompt
         )
         
+        let targetSize = CGSize(width: input.size?.width ?? sampleSize.width, height: input.size?.height ?? sampleSize.height)
+        let negativeScale = 0.5
         // Prepare added time ids & embeddings
         var timeIds = MLShapedArray<Float32>(scalars: [
             // original_size
-            Float32(sampleSize.height), Float32(sampleSize.width),
+            Float32(targetSize.height), Float32(targetSize.width),
             // crops_coords_top_left
             0, 0,
             // target_size
-            Float32(sampleSize.height), Float32(sampleSize.width)
+            Float32(targetSize.height), Float32(targetSize.width)
         ], shape: [1, 6])
+
         if doClassifierFreeGuidance {
-            timeIds = MLShapedArray<Float32>(concatenating: Array(repeating: timeIds, count: batchSize), alongAxis: 0)
+            let negativeTimeIds = MLShapedArray<Float32>(scalars: [
+                // original_size (negative)
+                Float32(targetSize.height * negativeScale), Float32(targetSize.width * negativeScale),
+                // crops_coords_top_left
+                0, 0,
+                // target_size
+                Float32(targetSize.height), Float32(targetSize.width)
+            ], shape: [1, 6])
+            timeIds = MLShapedArray<Float32>(concatenating: [negativeTimeIds, timeIds], alongAxis: 0)
+            timeIds = MLShapedArray<Float32>(concatenating: Array(repeating: timeIds, count: 1), alongAxis: 0)
         }
         
         let generator: RandomGenerator = TorchRandomGenerator(seed: input.seed)


### PR DESCRIPTION
- Technical reference:
https://github.com/lllyasviel/Fooocus#list-of-hidden-tricks
https://github.com/lllyasviel/Fooocus/blob/d16a54edd69f82158ae7ffe5669618db33a01ac7/modules/patch.py#L265
https://arxiv.org/pdf/2307.01952 (2.2 Micro-Conditioning)
https://huggingface.co/docs/diffusers/main/en/using-diffusers/sdxl#size-conditioning

- At present, both Fooocus and DrawThings use this trick. After testing, it does get better output results than ComfyUI, diffusers, GuernikaKit, with better color contrast and detail sharpness.
At the same time, it will also cause the same seed to be unable to reproduce the results of ComfyUI and diffusers.

- In addition, I set both the original size and the target size to the input size, and it should be able to get a better photographic composition. It can avoid the occurrence of repeated objects in a large aspect ratio such as 1536x640.

- The following is the comparison test. On the left is the result of not using this PR:
The premise is that I added another modification here:
https://github.com/GuernikaCore/Schedulers/blob/1f517514d679e38bb9915c3a74bf04f75d5b5875/Sources/Schedulers/DPMSolverMultistepScheduler.swift#L253
Do you have a better solution?
```swift
        modelOutputs.append(modelOutput)
        if stepIndex == timeSteps.count - 1 {
            return modelOutput
        }
```

- sampler: DPM++ 2M Karras, steps: 15
![100001](https://github.com/GuernikaCore/GuernikaKit/assets/90698189/f6a4a474-93fc-4d2c-b9c9-b80eec247684)
![100002](https://github.com/GuernikaCore/GuernikaKit/assets/90698189/2ba7d392-427b-4269-aa8c-f6cc3ccfe059)
![100003](https://github.com/GuernikaCore/GuernikaKit/assets/90698189/14e1b056-5441-40b4-b312-f6e119b72872)
![100004](https://github.com/GuernikaCore/GuernikaKit/assets/90698189/e26bd3bd-e728-4de6-921f-49c5ba4e16fb)
![100005](https://github.com/GuernikaCore/GuernikaKit/assets/90698189/f3206f68-69e7-4eab-a58c-00642080a795)
